### PR TITLE
WASMビルドプロセスを改善

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,19 +21,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup mise
-        uses: jdx/mise-action@v2
-        with:
-          version: 2024.1.0
-
       - name: Setup Node.js
-        run: mise install
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
+      - name: Build WASM
+        run: |
+          cd wasm
+          wasm-pack build --target web --out-dir pkg
+
+      - name: Copy WASM files
+        run: |
+          mkdir -p web/src/assets/pkg
+          cp -r wasm/pkg/* web/src/assets/pkg/
+
+      - name: Install dependencies
+        run: |
+          cd web
+          npm install
+
       - name: Build project
-        run: mise run build
+        run: |
+          cd web
+          npm run build
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,9 @@
 # 2D Prisoner's Dilemma - mise configuration
 # =============================================================================
 
+[settings]
+experimental = true
+
 [tools]
 node = "24"
 rust = "latest"
@@ -16,11 +19,8 @@ RUST_LOG = "debug"
 
 [tasks.dev]
 description = "🚀 開発開始"
-run = [
-  "cd wasm && wasm-pack build --target web --out-dir pkg",
-  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
-  "cd web && bun run dev"
-]
+depends = ["copy"]
+run = "cd web && bun run dev"
 
 [tasks.test]
 description = "🧪 テスト実行"
@@ -62,20 +62,13 @@ depends = ["wasm"]
 
 [tasks.build]
 description = "🏗️ 本番ビルド"
-run = [
-  "cd wasm && wasm-pack build --target web --out-dir pkg",
-  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
-  "cd web && bun run build"
-]
+depends = ["copy"]
+run = "cd web && bun run build"
 
 [tasks.preview]
 description = "👀 本番プレビュー"
-run = [
-  "cd wasm && wasm-pack build --target web --out-dir pkg",
-  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
-  "cd web && bun run build",
-  "cd web && bun run preview"
-]
+depends = ["build"]
+run = "cd web && bun run preview"
 
 # =============================================================================
 # 📊 WATCH COMMANDS - 監視系
@@ -122,12 +115,10 @@ run = "cargo doc --no-deps --open"
 
 [tasks.size]
 description = "📊 サイズ確認"
+depends = ["build"]
 run = [
-  "cd wasm && wasm-pack build --target web --out-dir pkg",
-  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
-  "cd web && bun run build",
   "ls -lh wasm/pkg/*.wasm",
-  "ls -lh web/build/assets/*.js"
+  "ls -lh web/dist/assets/*.js"
 ]
 
 [tasks.lint]
@@ -163,40 +154,36 @@ run = [
 
 [tasks.d]
 description = "🚀 開発開始 (短縮)"
-run = "mise run dev"
+depends = ["dev"]
 
 [tasks.t]
 description = "🧪 テスト実行 (短縮)"
-run = "mise run test"
+depends = ["test"]
 
 [tasks.c]
 description = "✅ 品質チェック (短縮)"
-run = "mise run check"
+depends = ["check"]
 
 [tasks.f]
 description = "🎨 コード整形 (短縮)"
-run = "mise run fmt"
+depends = ["fmt"]
 
 [tasks.tc]
 description = "🏷️ 型チェック (短縮)"
-run = "mise run type-check"
+depends = ["type-check"]
 
 [tasks.ci-short]
 description = "🚦 CI チェック (短縮)"
-run = "mise run ci"
+depends = ["ci"]
 
 [tasks.fc]
 description = "🔍 完全チェック (短縮)"
-run = "mise run full-check"
+depends = ["full-check"]
 
 [tasks.w]
 description = "👀 テスト監視 (短縮)"
-run = "mise run watch"
+depends = ["watch"]
 
 [tasks.b]
 description = "🏗️ 本番ビルド (短縮)"
-run = [
-  "cd wasm && wasm-pack build --target web --out-dir pkg",
-  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
-  "cd web && bun run build"
-]
+depends = ["build"]

--- a/.mise.toml
+++ b/.mise.toml
@@ -63,15 +63,17 @@ depends = ["wasm"]
 [tasks.build]
 description = "🏗️ 本番ビルド"
 run = [
-  "mise run wasm",
-  "mise run copy",
+  "cd wasm && wasm-pack build --target web --out-dir pkg",
+  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
   "cd web && bun run build"
 ]
 
 [tasks.preview]
 description = "👀 本番プレビュー"
 run = [
-  "mise run build",
+  "cd wasm && wasm-pack build --target web --out-dir pkg",
+  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
+  "cd web && bun run build",
   "cd web && bun run preview"
 ]
 
@@ -85,7 +87,7 @@ run = "cd wasm && cargo watch -x test"
 
 [tasks.watch-wasm]
 description = "🔄 WASM監視"
-run = "cd wasm && cargo watch -s 'mise run wasm && mise run copy'"
+run = "cd wasm && cargo watch -s 'wasm-pack build --target web --out-dir pkg && mkdir -p ../web/src/assets/pkg && cp -r pkg/* ../web/src/assets/pkg/'"
 
 # =============================================================================
 # 🛠️ SETUP COMMANDS - セットアップ
@@ -121,7 +123,9 @@ run = "cargo doc --no-deps --open"
 [tasks.size]
 description = "📊 サイズ確認"
 run = [
-  "mise run build",
+  "cd wasm && wasm-pack build --target web --out-dir pkg",
+  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
+  "cd web && bun run build",
   "ls -lh wasm/pkg/*.wasm",
   "ls -lh web/build/assets/*.js"
 ]
@@ -191,4 +195,8 @@ run = "mise run watch"
 
 [tasks.b]
 description = "🏗️ 本番ビルド (短縮)"
-run = "mise run build"
+run = [
+  "cd wasm && wasm-pack build --target web --out-dir pkg",
+  "mkdir -p web/src/assets/pkg && cp -r wasm/pkg/* web/src/assets/pkg/",
+  "cd web && bun run build"
+]


### PR DESCRIPTION
この Pull Request は、WebAssembly（`WASM`）アセットのビルドと管理において、`mise`コマンドの使用を直接的な`wasm-pack`とファイル操作コマンドに置き換えるために`.mise.toml`ファイルを更新しています。これらの変更は、ビルドとプレビュープロセスを効率化し、手順を明示的にすることで明確性を向上させることを目的としています。

### ビルドとプレビュープロセスの更新：
* `mise run wasm`と`mise run copy`コマンドを、`wasm-pack`を使用してWASMをビルドし、出力を適切なディレクトリ（`web/src/assets/pkg`）にコピーする明示的な手順に置き換えました。この変更は`build`、`preview`、`size`タスクに影響を与えます。[[1]](diffhunk://#diff-1bac9641068b68e6b60d0166663560d45b271c427fd863f8d56ed36964f99ee2L66-R76) [[2]](diffhunk://#diff-1bac9641068b68e6b60d0166663560d45b271c427fd863f8d56ed36964f99ee2L124-R128)

### ウォッチタスクの更新：
* `watch-wasm`タスクを更新し、`mise`コマンドに依存する代わりに`wasm-pack`とファイルコピーコマンドを直接使用するようにし、新しいアプローチとの一貫性を確保しました。

### 短縮ビルドタスクの更新：
* `b`（短縮ビルド）タスクを変更し、メインの`build`タスクと同じ明示的なWASMビルドとファイルコピーの手順を含むようにしました。